### PR TITLE
Fixed missing end code block

### DIFF
--- a/docs/30DaysOfPWA/advanced-capabilities/03.md
+++ b/docs/30DaysOfPWA/advanced-capabilities/03.md
@@ -59,6 +59,7 @@ async function sharePWinter() {
         console.error(e);
     }
 }
+```
 
 ### Sharing files
 The Web Share API also allows you to share files. This capability works with images, PDFs, audio, text documents, and video. The [full list of supported file types is here](https://aka.ms/learn-PWA/30Days-2.3/developer.mozilla.org/en-US/docs/Web/API/Navigator/share#shareable_file_types), but you should always test to ensure the sharing action works with the type of file you want to share. 
@@ -87,6 +88,7 @@ async function shareLogo() {
         console.log(`System doesn't support sharing.`);
     }
 };
+```
 
 ![Screenshot of the PWinter PWA sharing a custom SVG image](_media/day-03/pwinter-share.jpg)
 


### PR DESCRIPTION
2 of the code blocks in the article were missing the end triple backticks.
This was breaking the formatting of the article.
This fixes it.