### PR TITLE
Temporarily reverting back to normal md images

### DIFF
--- a/docs/30DaysOfPWA/advanced-capabilities/04.md
+++ b/docs/30DaysOfPWA/advanced-capabilities/04.md
@@ -26,14 +26,14 @@ In the event a browser doesn’t support a display mode, which is possible since
 ### Standalone display mode 
 The "standalone" display mode makes your PWA look and behave the most like a native application. It opens in a different window from the browser and hides all the browser UI elements like the address bar. It keeps standard system UI elements like a back button or a close window button. In this mode, your application can also have its own icon in the application launcher.  If standalone isn’t available, it will fall back to the "minimal-ui" display mode. Twitter uses "standalone" for their PWA.
 
-<!-- ![Twitter displayed in its own window on Android](_media/display-standalone.png) -->
-<img src="_media/display-standalone.png" alt="Twitter displayed in its own window on Android" style="max-width: 600px; display: block; margin-left: auto; margin-right: auto;" />
+![Twitter displayed in its own window on Android](_media/display-standalone.png)
+<!-- <img src="_media/display-standalone.png" alt="Twitter displayed in its own window on Android" style="max-width: 600px; display: block; margin-left: auto; margin-right: auto;" /> -->
 
 ### Fullscreen display mode
 The "fullscreen" display mode takes up the entirety of the display area available and hides all of the browser UI elements. If "fullscreen" isn’t available, it will fall back to "standalone." Here's an example of a game that uses the "fullscreen" display mode.
 
-<!-- ![This PacMan game is a PWA and was built with the fullscreen display mode](_media/display-fullscreen.png) -->
-<img src="_media/display-fullscreen.png" alt="This PacMan game is a PWA and was built with the fullscreen display mode" style="max-width: 600px; display: block; margin-left: auto; margin-right: auto;" />
+![This PacMan game is a PWA and was built with the fullscreen display mode](_media/display-fullscreen.png)
+<!-- <img src="_media/display-fullscreen.png" alt="This PacMan game is a PWA and was built with the fullscreen display mode" style="max-width: 600px; display: block; margin-left: auto; margin-right: auto;" /> -->
 
 View the PacMan PWA [here](https://bobrov.dev/pacman-pwa/index.html).
 


### PR DESCRIPTION
I see that the first 2 images have been moved to html images instead of md.
I think this was done because these images are very big and they were getting displayed full width which made the article harder to follow.
Unfortunately the path is not correct. Docsify does something weird with URLs, and the relative path used in the `img` tags wasn't getting resolved.

As a temporary measure, I'm reverting to the md files so that docsify correctly embeds the images.

If we later want to go back to styled html images, we should fix the path.