### PR TITLE
Update PWA start URL to properly navigate to 30days Landing page

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "30 Days of PWA",
     "short_name": "30DaysOfPWA",
-    "start_url": "/index.html",
+    "start_url": "/win-student-devs",
     "categories": [
         "productivity",
         "devtools",


### PR DESCRIPTION
Currently, after installing the 30 Days PWA, it will take you to opensource.microsoft.com

Now, it should open on 30 Days landing page.